### PR TITLE
Remove SiteDeploy.site_capabilities

### DIFF
--- a/netlify/schemas.py
+++ b/netlify/schemas.py
@@ -28,10 +28,6 @@ class SiteFile(BaseModel):
     deploy_id: str | None = None
 
 
-class SiteCapabilities(BaseModel):
-    large_media_enabled: bool | None = None
-
-
 class FunctionSchedules(BaseModel):
     name: str
     cron: str
@@ -66,7 +62,6 @@ class SiteDeploy(BaseModel):
     context: str
     locked: bool | None = None
     review_url: str | None = None
-    site_capabilities: SiteCapabilities
     framework: str | None = None
     function_schedules: list[FunctionSchedules]
 


### PR DESCRIPTION
This has been removed from the swagger: https://open-api.netlify.com/#tag/deploy/operation/createSiteDeploy

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for SiteDeploy
site_capabilities
'Field required [type=missing, input_value={'id': '...one, 'expires_at': None}, input_type=dict]
```