### PR TITLE
Fix pydantic deprecated issue

### DIFF
--- a/netlify/transport.py
+++ b/netlify/transport.py
@@ -6,6 +6,7 @@ import httpx
 
 from netlify.auth.bearer import BearerAuth
 from netlify.exceptions import NetlifyError, NetlifyErrorSchema
+from netlify.pydantic_polyfill import PydanticPolyfill
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,9 @@ class NetlifyTransport:
                 return response.json()
             except httpx.HTTPStatusError as http_err:
                 if "application/json" in response.headers.get("content-type", ""):
-                    error = NetlifyErrorSchema.parse_obj(response.json())
+                    error = PydanticPolyfill[NetlifyErrorSchema](
+                        NetlifyErrorSchema
+                    ).to_pydantic_object(response.json())
                     raise NetlifyError(method, path, error) from http_err
 
                 raise http_err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 
+[tool.pytest.ini_options]
+filterwarnings = [
+  "error::DeprecationWarning"
+]
+
 [tool.coverage.run]
 omit = [
   "*/__main__.py"


### PR DESCRIPTION
There was an issue where we were still using `parse_obj()` directly on a pydantic object instead of using the polyfill.

Enforcing all deprecation warnings raised as errors to stay ahead of other downstream deprecations.